### PR TITLE
Simplified Countdown_Intro Scene

### DIFF
--- a/FF2020_Proper.json
+++ b/FF2020_Proper.json
@@ -1685,6 +1685,45 @@
                 "id_counter": 2,
                 "items": [
                     {
+                        "name": "FF_Logo_Animation",
+                        "source_uuid": "44f36ed7-6126-4574-9338-38ed8426d997",
+                        "visible": true,
+                        "locked": false,
+                        "rot": 0.0,
+                        "pos": {
+                            "x": 0.0,
+                            "y": 0.0
+                        },
+                        "scale": {
+                            "x": 1.0,
+                            "y": 1.0
+                        },
+                        "align": 5,
+                        "bounds_type": 0,
+                        "bounds_align": 0,
+                        "bounds_crop": false,
+                        "bounds": {
+                            "x": 0.0,
+                            "y": 0.0
+                        },
+                        "crop_left": 0,
+                        "crop_top": 0,
+                        "crop_right": 0,
+                        "crop_bottom": 0,
+                        "id": 3,
+                        "group_item_backup": false,
+                        "scale_filter": "disable",
+                        "blend_method": "default",
+                        "blend_type": "normal",
+                        "show_transition": {
+                            "duration": 0
+                        },
+                        "hide_transition": {
+                            "duration": 0
+                        },
+                        "private_settings": {}
+                    },
+                    {
                         "align": 5,
                         "bounds": {
                             "x": 0.0,
@@ -1819,21 +1858,6 @@
                         "hidden": false,
                         "selected": false,
                         "value": "C:/stream/video/intro/FF_INTRO.webm"
-                    },
-                    {
-                        "hidden": false,
-                        "selected": false,
-                        "value": "C:/stream/video/logo_loops/ff_logo_loop_new.webm"
-                    },
-                    {
-                        "hidden": false,
-                        "selected": false,
-                        "value": "C:/stream/video/logo_loops/ff_logo_loop_new.webm"
-                    },
-                    {
-                        "hidden": false,
-                        "selected": false,
-                        "value": "C:/stream/video/logo_loops/ff_logo_loop_new.webm"
                     }
                 ]
             },


### PR DESCRIPTION
Added FF_Logo_Animation as looping background behind Countdown_Intro_Playlist, removed FF_Logo_Animation from Countdown_Intro_Playlist, to remove black frame inbetween loops of FF_Logo_Animation and remove stall at end of playlist